### PR TITLE
MantaClient signURL() disobeys optional algorithm arg

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -470,7 +470,6 @@ function cliSigner(options) {
  */
 function signUrl(opts, cb) {
     assert.object(opts, 'options');
-    assert.string(opts.algorithm, 'options.algorithm');
     assert.optionalNumber(opts.expires, 'options.expires');
     assert.string(opts.host, 'options.host,');
     assert.string(opts.keyId, 'options.keyId');
@@ -497,7 +496,7 @@ function signUrl(opts, cb) {
     var method = opts.method.join(',');
 
     var q = clone(opts.query || {});
-    q.algorithm = opts.algorithm;
+    q.algorithm = opts.sign.algorithm;
     q.expires = (opts.expires ||
                  Math.floor(((Date.now() + (1000 * 300))/1000)));
     q.keyId = '/' + opts.user + '/keys/' + opts.keyId;

--- a/lib/client.js
+++ b/lib/client.js
@@ -2071,13 +2071,12 @@ MantaClient.prototype.signURL = function signURL(opts, cb) {
 
     var self = this;
     var _opts = {
-        algorithm: opts.algorithm || self.sign.algorithm,
         expires: opts.expires || new Date().getTime() + (300 * 1000),
         host: require('url').parse(self._url).host,
         keyId: opts.keyId || self.sign.keyId || process.env.MANTA_KEY_ID,
         method: opts.method || ['GET'],
         path: getPath(opts.path),
-        sign: self.sign,
+        sign: opts.sign || self.sign,
         user: opts.user || self.sign.user || self.user
     };
 


### PR DESCRIPTION
The current code for signURL() in lib/client.js contains this:

```
var _opts = {
    algorithm: opts.algorithm || self.sign.algorithm,
    ...
    sign: self.sign,
    ...
};
```

Note that I can provide an alternate algorithm, but not sign. This becomes a problem because signUrl() in lib/auth.js doesn't actually obey any algorithm argument for the signing itself, it uses sign.

So this:

```
client.signURL({ path: '/marsell/stor/foobar', expires: 1374047343, algorithm: 'rsa-sha1' }, function (err, url) {
    ...
});
```

Will generate a signed URL claiming to be &algorithm=rsa-sha1, when it's likely something else (whatever was used during client construction). In my case, it claims to be rsa-sha1, when it's actually rsa-sha256 that was used for signing.

I think the correct fix here is to remove the _algorithm_ optional arg from both signURL and signUrl, and allow users of signURL to provide their own sign arg. Anything else is asking for unnecessary trouble.
