### PR TITLE
fix omitted command in an mjob manpage example

### DIFF
--- a/man/man1/mjob.1
+++ b/man/man1/mjob.1
@@ -267,7 +267,7 @@ call).  Optionally takes a \fB\fC-s\fR, that can be used to filter down to only
 .PP
 .RS
 .nf
-$ mjob -s running
+$ mjob list -s running
 .fi
 .RE
 .TP


### PR DESCRIPTION
$ mjob -s running
should've been
$ mjob list -s running
