### PR TITLE
auth: sshAgentSigner now works

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -262,6 +262,7 @@ function sshAgentSigner(options) {
     assert.string(options.user, 'options.user');
 
     var agent = new SSHAgentClient();
+    agent._signCache = {};                              // Required by sshAgentSign
     var keyId = options.keyId;
 
     function sign(str, cb) {


### PR DESCRIPTION
Otherwise the assert in sshAgentSign for ._signCache fails.
