### PR TITLE
be more specific with hashtag when we tweet a job share

### DIFF
--- a/share/jobtemplate.htm
+++ b/share/jobtemplate.htm
@@ -161,7 +161,7 @@ table.jObjectTable td {
 <div class="jHeader">Joyent Manta
 <div class="jHeaderRight">
 <a href="https://twitter.com/share" class="twitter-share-button"
-data-via="joyent" data-size="large" data-count="none" data-hashtags="manta"
+data-via="joyent" data-size="large" data-count="none" data-hashtags="joyentmanta"
 data-dnt="true">Tweet</a>
 <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 </div>


### PR DESCRIPTION
The #manta namespace on Twitter has a bad signal-to-noise ratio.
