### PR TITLE
Add headers to cloneOptions

### DIFF
--- a/lib/create_client.js
+++ b/lib/create_client.js
@@ -66,6 +66,7 @@ function cloneOptions(options) {
     return ({
         agent: options.agent,
         connectTimeout: options.connectTimeout || 4000,
+        headers: options.headers,
         rejectUnauthorized: options.rejectUnauthorized,
         retry: options.retry,
         sign: options.sign,


### PR DESCRIPTION
Right now in order to pass predefined headers to client, I have to add them after creating client, like this:

```
var client = manta.createClient({
    sign: manta.privateKeySigner({...}),
    user: ...,
    url: ...
});
client.client.headers['X-Auth-Token'] = ...;
```

I'd prefer to have it in client constructor:

```
var client = manta.createClient({
    sign: manta.privateKeySigner({...}),
    user: ...,
    url: ...,
    headers: {
         'X-Auth-Token': ...
    }
});
```
