### PR TITLE
use path.posix when dealing with manta paths

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -1522,7 +1522,7 @@ function doPut(self, log, options, input, cb, allowretry) {
 
                     log.debug('put with mkdirp: mkdirp');
                     var parent =
-                        path.dirname(path.normalize(options._original_path));
+                        path.posix.dirname(path.posix.normalize(options._original_path));
                     self.mkdirp(parent, function onMkdirp(mkdirperr) {
                         if (mkdirperr) {
                             log.debug(mkdirperr, 'put with mkdirp: error');


### PR DESCRIPTION
this fixes a bug on windows when a dir is lazily created using `client.put()`

ie. `client.put('/foo/bar/baz')`: If this yields a `DirectoryDoesNotExistError`, it will attempt to:

``` js
client.mkdirp(path.dirname(path.normalize('/foo/bar/baz')))
```

(as expected).

However, on Windows, this will result in `client.mkdirp('\\foo\\bar')`, which will fail when the request is made to manta.  This issue can be avoided by using `path.posix` for any and all path related calls that deal with manta paths.

discovered by @papertigers - https://github.com/bahamas10/node-manta-sync/pull/14
