### PR TITLE
allow custom ssh-agent options to be passed to constructor

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -242,12 +242,12 @@ function sshAgentGetKey(client, fp, cb) {
 }
 
 
-function createSSHAgent(cb) {
+function createSSHAgent(sshAgentOpts, cb) {
     assert.func(cb, 'callback');
 
     var agent;
     try {
-        agent = new SSHAgentClient();
+        agent = new SSHAgentClient(sshAgentOpts);
     } catch (e) {
         cb(e);
         return;
@@ -423,7 +423,7 @@ function cliSigner(options) {
     vasync.pipeline({
         funcs: [
             function createAgent(opts, cb) {
-                createSSHAgent(function (err, agent) {
+                createSSHAgent(options.sshAgentOpts, function (err, agent) {
                     if (err) {
                         cb();
                         return;

--- a/lib/create_client.js
+++ b/lib/create_client.js
@@ -203,6 +203,7 @@ function createBinClient(opts) {
     opts.sign = null;
     if (!opts.noAuth) {
         opts.sign = auth.cliSigner({
+            sshAgentOpts: opts.sshAgentOpts,
             algorithm: opts.algorithm,
             keyId: opts.keyId,
             log: opts.log,


### PR DESCRIPTION
this change for node v0.12.0 https://github.com/mcavage/node-ssh-agent/pull/5 is causing issues with `manta-sync` when running with a large amount of files in parallel (default is 50 which triggers the issues).  The timeout of 1s when signing with the `ssh-agent` was never enforced before, but now that it is it seems a lot of users are hitting it... although I can't personally reproduce this.

This change makes it so `opts.sshAgentOpts` can be set when calling `createBinClient`, and the entire object will be sent to the `SSHAgentClient` constructor.  For example, in `manta-sync` I will add a line like this:

``` js
opts.sshAgentOpts = {timeout: 5000};
var client = manta.createBinClient(opts);
```

where `5000` will be taken from the command line or set to a default higher than 1 second.