### PR TITLE
escape control characters for mls, fixes #231

### DIFF
--- a/bin/mls
+++ b/bin/mls
@@ -123,6 +123,7 @@ function parseOptions() {
 
 
 function printEntry(opts, obj) {
+    var safename = manta.escapePath(obj.name);
     if (opts.json || opts.fulljson) {
         if (!opts.fulljson) {
             if (obj.headers) {
@@ -149,12 +150,12 @@ function printEntry(opts, obj) {
                           owner,
                           (obj.type === 'directory' ? '0' : (obj.size || '0')),
                           d.format(fmt),
-                          obj.name);
+                          safename);
 
         console.log(out);
     } else {
         console.log('%s%s',
-                    obj.name,
+                    safename,
                     obj.type === 'directory' ? '/' : '');
     }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var manta = require('./client');
 var progbar = require('progbar');
 var Queue = require('./queue');
 var StringStream = require('./string_stream');
+var utils = require('./utils');
 
 
 
@@ -41,5 +42,6 @@ module.exports = {
     cli_logger: cc.setupLogger,
     StringStream: StringStream,
     path: manta.path,
-    jobPath: manta.jobPath
+    jobPath: manta.jobPath,
+    escapePath: utils.escapePath
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,13 @@
+// Copyright (c) 2015, Joyent, Inc. All rights reserved.
+
+var assert = require('assert-plus');
+
+module.exports = {
+    escapePath: escapePath
+};
+
+function escapePath(s) {
+    assert.string(s, 'escapePath');
+    /*JSSTYLED*/
+    return (JSON.stringify(s).replace(/^"|"$/g, '').replace(/\\"/g, '"'));
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,30 @@
+// Copyright 2015 Joyent.  All rights reserved.
+
+var manta = require('..');
+
+var helper = require('./helper.js');
+var test = helper.test;
+
+// a name on the left should match the name on the right
+// when escaped.
+test('escapePath encoding', function (t) {
+    var tests = [
+        // simple tests, no effect
+        ['foo', 'foo'],
+        ['bar', 'bar'],
+
+        // special characters
+        ['one\rtwo', 'one\\rtwo'],
+        ['one\ntwo', 'one\\ntwo'],
+        ['one\ttwo', 'one\\ttwo'],
+
+        // ANSI escape chars
+        ['red\x1b[31mcolor', 'red\\u001b[31mcolor']
+    ];
+
+    tests.forEach(function (_test) {
+        var s = _test[0];
+        t.equal(manta.escapePath(s), _test[1]);
+    });
+    t.end();
+});


### PR DESCRIPTION
```
$ echo test | mput $'~~/stor/test/before-\r-after'
-after          
$ mls ~~/stor/test
-after-
$ ./bin/mls ~~/stor/test
before-\r-after
```

The first invocation of `mls` is what is currently in `npm`, and the second is with this patch.

I've opted to *not* modify the output of `mfind`, as what `mfind` currently outputs is technically *correct*.  If `mfind` were to escape the object names, compute on manta that uses `mfind` to gather a list of objects may not work as expected.