### PR TITLE
sugar around `msign -e`, fixes #61

### DIFF
--- a/bin/msign
+++ b/bin/msign
@@ -28,9 +28,9 @@ var OPTIONS_PARSER = dashdash.createParser({
     options: manta.DEFAULT_CLI_OPTIONS.concat([
         {
             names: ['expires', 'e'],
-            type: 'positiveInteger',
-            help: 'expiration time (epoch). Default is 1hr from now.',
-            'default': Math.floor((new Date().getTime() / 1000) + 3600),
+            type: 'string',
+            help: 'expiration time (epoch|relative). Default is 1h from now.',
+            'default': '1h',
             helpArg: 'EXPIRATION'
         },
         {
@@ -120,13 +120,49 @@ function parseOptions() {
     } catch (e) {
         ifError(e);
     }
+    // normalize expires option
+    var expires;
+    var match;
+    if ((match = opts.expires.match(/^([0-9]+)([smhdwy])$/))) {
+        var now = Math.floor(Date.now() / 1000);
+        var num = parseInt(match[1], 10);
+        switch (match[2]) {
+        case 's':
+            expires = now + (num);
+            break;
+        case 'm':
+            expires = now + (num * 60);
+            break;
+        case 'h':
+            expires = now + (num * 60 * 60);
+            break;
+        case 'd':
+            expires = now + (num * 60 * 60 * 24);
+            break;
+        case 'w':
+            expires = now + (num * 60 * 60 * 24 * 7);
+            break;
+        case 'y':
+            expires = now + (num * 60 * 60 * 24 * 365);
+            break;
+        default:
+            ifError(new Error('invalid expires: ' + opts.expires));
+            break;
+        }
+    } else if ((match = opts.expires.match(/^([0-9]+)$/))) {
+        expires = parseInt(opts.expires, 10);
+    } else {
+        ifError(new Error('invalid expires: ' + opts.expires));
+        return;
+    }
+
     opts.paths.forEach(function (p) {
 
         ifError(manta.assertPath(p, true));
 
         var _opts = {
             algorithm: opts.algorithm,
-            expires: opts.expires,
+            expires: expires,
             host: url.parse(opts.url).host,
             keyId: opts.keyId,
             log: opts.log,

--- a/docs/man/msign.md
+++ b/docs/man/msign.md
@@ -20,22 +20,38 @@ time-expiring URLs that can be shared with others.  This is useful to generate
 HTML links, for example.
 
 The default expiration for URLs is 1 hour from `now`, but this can be changed
-with the `expires` option.  The expires option is designed to be used in
-conjunction with the UNIX date command.  In general, you should use the date
-command with a modifier (the syntax is different between BSD and GNU forms), and
-format the output to epoch time.
+with the `expires` option - see `EXPIRATION` below.
 
 EXAMPLES
 --------
 
-Assuming the GNU date command, generate a signed URL that expires in one month:
+Generate a signed URL that expires in 5 seconds:
 
-    $ msign -e $(date -d "1 month" "+%s") ~~/stor/tmp
+    $ msign -e 5s ~~/stor/tmp
 
-On OS X, you would sign this way:
+Generate a signed URL that expires in 5 minutes:
 
-    $ msign -e $(date -v+1m "+%s") ~~/stor/tmp
+    $ msign -e 5m ~~/stor/tmp
 
+Generate a signed URL that expires in 5 hours:
+
+    $ msign -e 5h ~~/stor/tmp
+
+Generate a signed URL that expires in 5 days:
+
+    $ msign -e 5d ~~/stor/tmp
+
+Generate a signed URL that expires in 5 weeks:
+
+    $ msign -e 5w ~~/stor/tmp
+
+Generate a signed URL that expires in 5 years:
+
+    $ msign -e 5y ~~/stor/tmp
+
+Generate a signed URL that expires at Wed Jan 20 20:42:01 UTC 2016:
+
+    $ msign -e 1453322521 ~~/stor/tmp
 
 OPTIONS
 -------
@@ -44,8 +60,8 @@ OPTIONS
   Authenticate as account (login name).
 
 `-e, --expires expiration`
-  Signed URL should last until EXPIRATION (seconds since epoch).  Default is 1
-  hour from `now`.
+  Expiration time in a relative form or seconds since epoch - see `EXPIRATION`
+  below for a more detailed explanation. Default is 1 hour from `now`.
 
 `-h, --help`
   Print a help message and exit.
@@ -100,6 +116,32 @@ ENVIRONMENT
 
 The shortcut `~~` is equivalent to `/:login`
 where `:login` is the account login name.
+
+EXPIRATION
+----------
+
+The `-e` argument can be given in multiple forms.  If just a number is given,
+it will be used as the seconds since epoch.  If a number followed by a valid
+modifier character is given it will be used as a relative date.  Valid
+modifiers are:
+
+`s`
+  Seconds from now
+
+`m`
+  Minutes from now
+
+`h`
+  Hours from now
+
+`d`
+  Days from now
+
+`w`
+  Weeks from now
+
+`y`
+  Years from now
 
 DIAGNOSTICS
 -----------

--- a/man/man1/msign.1
+++ b/man/man1/msign.1
@@ -13,25 +13,62 @@ time\-expiring URLs that can be shared with others.  This is useful to generate
 HTML links, for example.
 .PP
 The default expiration for URLs is 1 hour from \fB\fCnow\fR, but this can be changed
-with the \fB\fCexpires\fR option.  The expires option is designed to be used in
-conjunction with the UNIX date command.  In general, you should use the date
-command with a modifier (the syntax is different between BSD and GNU forms), and
-format the output to epoch time.
+with the \fB\fCexpires\fR option \- see \fB\fCEXPIRATION\fR below.
 .SH EXAMPLES
 .PP
-Assuming the GNU date command, generate a signed URL that expires in one month:
+Generate a signed URL that expires in 5 seconds:
 .PP
 .RS
 .nf
-$ msign \-e $(date \-d "1 month" "+%s") ~~/stor/tmp
+$ msign \-e 5s ~~/stor/tmp
 .fi
 .RE
 .PP
-On OS X, you would sign this way:
+Generate a signed URL that expires in 5 minutes:
 .PP
 .RS
 .nf
-$ msign \-e $(date \-v+1m "+%s") ~~/stor/tmp
+$ msign \-e 5m ~~/stor/tmp
+.fi
+.RE
+.PP
+Generate a signed URL that expires in 5 hours:
+.PP
+.RS
+.nf
+$ msign \-e 5h ~~/stor/tmp
+.fi
+.RE
+.PP
+Generate a signed URL that expires in 5 days:
+.PP
+.RS
+.nf
+$ msign \-e 5d ~~/stor/tmp
+.fi
+.RE
+.PP
+Generate a signed URL that expires in 5 weeks:
+.PP
+.RS
+.nf
+$ msign \-e 5w ~~/stor/tmp
+.fi
+.RE
+.PP
+Generate a signed URL that expires in 5 years:
+.PP
+.RS
+.nf
+$ msign \-e 5y ~~/stor/tmp
+.fi
+.RE
+.PP
+Generate a signed URL that expires at Wed Jan 20 20:42:01 UTC 2016:
+.PP
+.RS
+.nf
+$ msign \-e 1453322521 ~~/stor/tmp
 .fi
 .RE
 .SH OPTIONS
@@ -40,8 +77,8 @@ $ msign \-e $(date \-v+1m "+%s") ~~/stor/tmp
 Authenticate as account (login name).
 .TP
 \fB\fC\-e, \-\-expires expiration\fR
-Signed URL should last until EXPIRATION (seconds since epoch).  Default is 1
-hour from \fB\fCnow\fR\&.
+Expiration time in a relative form or seconds since epoch \- see \fB\fCEXPIRATION\fR
+below for a more detailed explanation. Default is 1 hour from \fB\fCnow\fR\&.
 .TP
 \fB\fC\-h, \-\-help\fR
 Print a help message and exit.
@@ -94,6 +131,30 @@ In place of \fB\fC\-i, \-\-insecure\fR\&.
 .PP
 The shortcut \fB\fC~~\fR is equivalent to \fB\fC/:login\fR
 where \fB\fC:login\fR is the account login name.
+.SH EXPIRATION
+.PP
+The \fB\fC\-e\fR argument can be given in multiple forms.  If just a number is given,
+it will be used as the seconds since epoch.  If a number followed by a valid
+modifier character is given it will be used as a relative date.  Valid
+modifiers are:
+.TP
+\fB\fCs\fR
+Seconds from now
+.TP
+\fB\fCm\fR
+Minutes from now
+.TP
+\fB\fCh\fR
+Hours from now
+.TP
+\fB\fCd\fR
+Days from now
+.TP
+\fB\fCw\fR
+Weeks from now
+.TP
+\fB\fCy\fR
+Years from now
 .SH DIAGNOSTICS
 .PP
 When using the \fB\fC\-v\fR option, diagnostics will be sent to stderr in bunyan


### PR DESCRIPTION
- `msign -e 5s ~~/foo` - expires in 5 seconds
- `msign -e 5m ~~/foo` - expires in 5 minutes
- `msign -e 5h ~~/foo` - expires in 5 hours
- `msign -e 5d ~~/foo` - expires in 5 days
- `msign -e 5w ~~/foo` - expires in 5 weeks
- `msign -e 5y ~~/foo` - expires in 5 years
- `msign -e 123456 ~~/foo` - expires at epoch 123456

fully backwards compatible... opt-in new behavior.

cc @jperkin @jclulow @trentm 

[edit]wrote backwards incompatible, meant compatible[/edit]
