### PR TITLE
local file to upload('-f' option) can be stdin ('-')

### DIFF
--- a/bin/muntar
+++ b/bin/muntar
@@ -51,7 +51,7 @@ function optionsParser(name) {
             {
                 names: ['file', 'f'],
                 type: 'string',
-                help: 'local file to upload (required)',
+                help: 'local file to upload (required).  Use \'-\' to read from standard input.',
                 helpArg: 'FILE'
             },
             {
@@ -171,7 +171,7 @@ function put(client, path, stream, opts, cb) {
 function worker(client, tarball, callback, log) {
     var entry = 0;
     var inflight = 1;
-    var stream = fs.createReadStream(tarball.file);
+    var stream = (tarball.file == "-") ? process.stdin : fs.createReadStream(tarball.file);
     var pipe = stream.pipe(tar.Parse());
     var options = tarball.options;
 


### PR DESCRIPTION
This small commit enables to use `-` for `-f` option value so that *muntar* can read from standard input instead from reading from real file.   In short, users can able to use following one-liner to upload files in a directory to manta.

        $ tar -C SOME-DIRECTORY -cf - . | muntar -f - ~~/MANTA-DIRECTORY

Without this commit, users should use one of following to upload a directory:

        $ tar -cf ARCHIVE.tar SOME-DIRECTORY
        $ muntar -f ARCHIVE.tar ~~/public

Or, if the shell is bash or zsh, users can use process substitution feature like this:

        $ muntar -f <(tar -cf - SOME-DIRECTORY) ~~/public


