### PR TITLE
mchmod command stopped working after v5.1.1

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -84,11 +84,12 @@ function parseOptions(args) {
                         assert.ifError(utils.assertPath(p, true));
                         return (client.path(p, true));
                     };
-    opts.paths = opts._args.map(getPath);
 
     if (args.parseCmdOptions) {
         args.parseCmdOptions(opts, parser);
     }
+
+    opts.paths = opts._args.map(getPath);
 
     try {
         cc.checkBinEnv(opts);


### PR DESCRIPTION
mchmod thinks the [+-=]role is a manta path, this is because parseCmdOptions happens after the map on all arguments which assumes the rest are manta paths.