### PR TITLE
MANTA-5193 Conditional headers do not support PUT only if not exist criteria

### DIFF
--- a/test/integration/buckets-client-condreq.test.js
+++ b/test/integration/buckets-client-condreq.test.js
@@ -101,7 +101,7 @@ test('buckets client conditional requests', testOpts, function (suite) {
         var inStream = fs.createReadStream(SMALL_FILE_PATH);
         var reqOpts = {
             headers: {
-                // XXX
+                'if-none-match': '*',
                 'm-foo': 'bar'
             }
         };
@@ -376,6 +376,25 @@ test('buckets client conditional requests', testOpts, function (suite) {
     /*
      * CREATE
      */
+
+    test('CreatebucketObject: if-match (bad, *)', function (t) {
+        var inStream = fs.createReadStream(SMALL_FILE_PATH);
+        var reqOpts = {
+            headers: {
+                'if-match': '*'
+            }
+        };
+        client.createBucketObject(inStream, BUCKET_NAME, 'new-object', reqOpts,
+                                  function (err, res) {
+
+            t.ok(err);
+            t.ok(res);
+
+            t.equal(err.code, 'PreconditionFailed');
+
+            t.end();
+        });
+    });
 
     test('CreateBucketObject: if-match (bad)', function (t) {
         var inStream = fs.createReadStream(SMALL_FILE_PATH);

--- a/test/integration/buckets-client-condreq.test.js
+++ b/test/integration/buckets-client-condreq.test.js
@@ -377,7 +377,9 @@ test('buckets client conditional requests', testOpts, function (suite) {
      * CREATE
      */
 
-    test('CreatebucketObject: if-match (bad, *)', function (t) {
+    test('CreateBucketObject: if-match (* on non-existent object)',
+        function (t) {
+
         var inStream = fs.createReadStream(SMALL_FILE_PATH);
         var reqOpts = {
             headers: {
@@ -505,6 +507,50 @@ test('buckets client conditional requests', testOpts, function (suite) {
              * XXX Why no `res.statusCode` from client, like `get` does.
              */
             t.equal(err.code, 'PreconditionFailed');
+
+            headAndAssert(t, function (res) {
+                t.equal(res.headers['m-foo'], 'wut');
+                t.ok(!res.headers['m-bar']);
+                t.end();
+            });
+        });
+    });
+
+    test('UpdateBucketObject: if-match (* on non-existent objects)',
+        function (t) {
+
+        client.putBucketObjectMetadata(BUCKET_NAME, 'new-object', {
+            headers: {
+                'm-foo': 'test',
+                'if-match': '*'
+            } }, function (err, res) {
+
+            t.ok(err);
+            t.ok(res);
+
+            t.equal(err.code, 'PreconditionFailed');
+
+            headAndAssert(t, function (res) {
+                t.equal(res.headers['m-foo'], 'wut');
+                t.ok(!res.headers['m-bar']);
+                t.end();
+            });
+        });
+    });
+
+    test('UpdateBucketObject: if-none-match (* on non-existent object)',
+        function (t) {
+
+        client.putBucketObjectMetadata(BUCKET_NAME, 'new-object', {
+            headers: {
+                'm-foo': 'test',
+                'if-none-match': '*'
+            } }, function (err, res) {
+
+            t.ok(err);
+            t.ok(res);
+
+            t.equal(err.code, 'ObjectNotFound');
 
             headAndAssert(t, function (res) {
                 t.equal(res.headers['m-foo'], 'wut');


### PR DESCRIPTION
Testing notes are in MANTA-5193. These changes were used as a driver to check that https://github.com/joyent/manta-buckets-mdapi/pull/53 is working as expected.